### PR TITLE
feat: let the user overwrite the released value

### DIFF
--- a/lib/success.ts
+++ b/lib/success.ts
@@ -61,17 +61,15 @@ async function findOrCreateVersion(
     } as any;
   } else {
     const descriptionText = description || '';
+    const released = typeof context.branch !== 'string' ? !context.branch.prerelease : false;
     const parameters: CreateVersion = {
       name,
       projectId: project.id as any,
       description: descriptionText,
       startDate: activeSprint?.startDate,
-      released: Boolean(config.released),
+      released: Boolean(config.released ?? released),
       releaseDate: config.setReleaseDate ? (new Date().toISOString()) : undefined,
     };
-    if (!parameters.released && typeof context.branch !== 'string') {
-      parameters.released = !context.branch.prerelease;
-    }
     newVersion = await jira.projectVersions.createVersion(parameters);
   }
 


### PR DESCRIPTION
<!--
## Pull Request template
-->
### Description
If the config says "released: false" then the plugin should respect that and not create the release as "released". 

### This is a 
<!-- Pick One -->
- [ ] Bug Fix
- [X] Feature
- [ ] Documentation
- [ ] Other

## Checklists
#### Commit style
   <!-- Check all the following -->
   - [ ] Changes are on a branch with a descriptive name eg. `fix/missing-queue`, `docs/setup-guide`
   
   - [X] Commits start with one of `feat:` `fix:` `docs:` `chore:` or similar
   
   - [X] No excessive commits, eg: there should be no `fix:` commits for bugs that existed only on the PR branch (see [guide-to-interactive-rebasing](https://hackernoon.com/beginners-guide-to-interactive-rebasing-346a3f9c3a6d))

#### Protected files

The following files should not change unless they are directly a part of your change.
    <!-- Check any of the bellow files that have changed, add a reason for each if nessesary  -->
   - [X] `yarn.lock` (unless package.json is also modified, then only the new/updated package should be changed here)
   
   - [X] `package.json` (renovate bot should handle all routine updates)
   
   - [X] `tsconfig.json` (only make it stricter, making it more lenient requires more discussion)
   
   - [X] `tslint.json` (only make it stricter, making it more lenient requires more discussion)
